### PR TITLE
Add test end point

### DIFF
--- a/lib/sunat/delivery/bill_response.rb
+++ b/lib/sunat/delivery/bill_response.rb
@@ -3,6 +3,7 @@ module SUNAT
     class BillResponse
       CORRECT_CODE = 0
       RESPONSE_CODE_KEY = 'cbc:ResponseCode'
+      RESPONSE_DESCRIPTION_KEY = 'cbc:Description'
 
       attr_reader :content
 
@@ -19,16 +20,21 @@ module SUNAT
       end
 
       def status_code
-        @code ||=  begin
-                    data = zipper.read_string(Base64.decode64(@content))
-                    Nokogiri::XML(data.first).xpath("//#{RESPONSE_CODE_KEY}").first.text.to_i
-                  end
+        @code ||= Nokogiri::XML(data.first).xpath("//#{RESPONSE_CODE_KEY}").first.text.to_i
+      end
+
+      def description
+        @description ||= Nokogiri::XML(data.first).xpath("//#{RESPONSE_DESCRIPTION_KEY}").first.text
       end
 
       private
 
       def zipper
         @zipper ||= Zipper.new
+      end
+
+      def data
+        @data ||= zipper.read_string(Base64.decode64(@content))
       end
     end
   end

--- a/lib/sunat/delivery/sender.rb
+++ b/lib/sunat/delivery/sender.rb
@@ -4,11 +4,12 @@ module SUNAT
   module Delivery
     class Sender
       attr_reader :name, :encoded_zip, :operation, :client, :operation
-      
+
 
       ADDRESSES = {:homologation => "https://www.sunat.gob.pe/ol-ti-itcpgem-sqa/billService?wsdl",
-                   :production => "https://www.sunat.gob.pe/ol-ti-itcpgem/billService?wsdl"}
-      
+                   :production => "https://www.sunat.gob.pe/ol-ti-itcpgem/billService?wsdl",
+                   :test => "https://www.sunat.gob.pe:443/ol-ti-itcpgem-beta/billService?wsdl"}
+
       def address
         ADDRESSES[SUNAT.environment]
       end


### PR DESCRIPTION
- Add test endpoint in order to be able to make test calls to Sunat soap service.
- Add description in `BillResponse` in order to get the message of the error if the approval of the invoice document fails.